### PR TITLE
Adding support for request timeouts and retries

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -114,6 +114,10 @@ async function startLangServer(context: vscode.ExtensionContext) {
         "--log-level", config.get<string>("log.level"),
         "--log-pretty-print", prettyPrint.toString(),
         "--indent-size", indentSize.toString(10),
+        "--timeout-ms", config.get<number>("timeoutMs").toString(),
+        "--max-retry-attempts", config.get<number>("retry.maxAttempts").toString(),
+        "--min-retry-sleep-time-ms", config.get<number>("retry.minSleepTimeMs").toString(),
+        "--max-retry-sleep-time-ms", config.get<number>("retry.maxSleepTimeMs").toString(),
         "--extension-id", context.extension.id,
     ];
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,30 @@
                     "type": "number",
                     "default": 4,
                     "description": "Number of spaces for each level of indentation."
+                },
+                "LFortran.timeoutMs": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 100,
+                    "description": "Number of milliseconds to await requests from server-to-client."
+                },
+                "LFortran.retry.maxAttempts": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 3,
+                    "description": "Maximum number of times to attempt a request before giving up."
+                },
+                "LFortran.retry.minSleepTimeMs": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 10,
+                    "description": "Minimum number of milliseconds to wait between request attempts."
+                },
+                "LFortran.retry.maxSleepTimeMs": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 300,
+                    "description": "Maximum number of milliseconds to wait between request attempts."
                 }
             }
         }


### PR DESCRIPTION
Changes:
* Adds configuration option for how many milliseconds to wait before timing-out a request.
* Adds configuration options that bound how long to wait between retry attempts.
* Adds configuration option that specifies the maximum number of times to retry a request before failing it.